### PR TITLE
Outputs w std fmt

### DIFF
--- a/src/Dolphyn.jl
+++ b/src/Dolphyn.jl
@@ -119,7 +119,18 @@ genx_to_exclude = [
     joinpath(genxsubmod_path,"model","solve_model.jl"),
     joinpath(genxsubmod_path,"model","generate_model.jl"),
     joinpath(genxsubmod_path,"configure_solver"),
+    joinpath(genxsubmod_path,"write_outputs","write_capacity.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_capacityfactor.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_charging_cost.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_energy_revenue.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_net_revenue.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_nw_expansion.jl"),
     joinpath(genxsubmod_path,"write_outputs","write_outputs.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_price.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_reliability.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_storage.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_storagedual.jl"),
+    joinpath(genxsubmod_path,"write_outputs","write_subsidy_revenue.jl"),
     # joinpath(genxsubmod_path,"configure_settings") # DOLPHYN and GenX are using different approaches, so we need both
 ]
 include_from_dir(genxsubmod_path, ".jl", genx_to_exclude)

--- a/src/GenX_extensions/write_capacity.jl
+++ b/src/GenX_extensions/write_capacity.jl
@@ -1,0 +1,96 @@
+@doc raw"""
+	write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Model))
+
+Function for writing the diferent capacities for the different generation technologies (starting capacities or, existing capacities, retired capacities, and new-built capacities).
+"""
+function write_capacity(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	# Capacity decisions
+	dfGen = inputs["dfGen"]
+	MultiStage = setup["MultiStage"]
+	
+	capdischarge = zeros(size(inputs["RESOURCES"]))
+	for i in inputs["NEW_CAP"]
+		if i in inputs["COMMIT"]
+			capdischarge[i] = value(EP[:vCAP][i])*dfGen[!,:Cap_Size][i]
+		else
+			capdischarge[i] = value(EP[:vCAP][i])
+		end
+	end
+
+	retcapdischarge = zeros(size(inputs["RESOURCES"]))
+	for i in inputs["RET_CAP"]
+		if i in inputs["COMMIT"]
+			retcapdischarge[i] = first(value.(EP[:vRETCAP][i]))*dfGen[!,:Cap_Size][i]
+		else
+			retcapdischarge[i] = first(value.(EP[:vRETCAP][i]))
+		end
+	end
+
+	capcharge = zeros(size(inputs["RESOURCES"]))
+	retcapcharge = zeros(size(inputs["RESOURCES"]))
+	existingcapcharge = zeros(size(inputs["RESOURCES"]))
+	for i in inputs["STOR_ASYMMETRIC"]
+		if i in inputs["NEW_CAP_CHARGE"]
+			capcharge[i] = value(EP[:vCAPCHARGE][i])
+		end
+		if i in inputs["RET_CAP_CHARGE"]
+			retcapcharge[i] = value(EP[:vRETCAPCHARGE][i])
+		end
+		existingcapcharge[i] = MultiStage == 1 ? value(EP[:vEXISTINGCAPCHARGE][i]) : dfGen[!,:Existing_Charge_Cap_MW][i]
+	end
+
+	capenergy = zeros(size(inputs["RESOURCES"]))
+	retcapenergy = zeros(size(inputs["RESOURCES"]))
+	existingcapenergy = zeros(size(inputs["RESOURCES"]))
+	for i in inputs["STOR_ALL"]
+		if i in inputs["NEW_CAP_ENERGY"]
+			capenergy[i] = value(EP[:vCAPENERGY][i])
+		end
+		if i in inputs["RET_CAP_ENERGY"]
+			retcapenergy[i] = value(EP[:vRETCAPENERGY][i])
+		end
+		existingcapenergy[i] = MultiStage == 1 ? value(EP[:vEXISTINGCAPENERGY][i]) :  dfGen[!,:Existing_Cap_MWh][i]
+	end
+	dfCap = DataFrame(
+		Resource = inputs["RESOURCES"], Zone = dfGen[!,:Zone],
+		StartCap = MultiStage == 1 ? value.(EP[:vEXISTINGCAP]) : dfGen[!,:Existing_Cap_MW],
+		RetCap = retcapdischarge[:],
+		NewCap = capdischarge[:],
+		EndCap = value.(EP[:eTotalCap]),
+		StartEnergyCap = existingcapenergy[:],
+		RetEnergyCap = retcapenergy[:],
+		NewEnergyCap = capenergy[:],
+		EndEnergyCap = existingcapenergy[:] - retcapenergy[:] + capenergy[:],
+		StartChargeCap = existingcapcharge[:],
+		RetChargeCap = retcapcharge[:],
+		NewChargeCap = capcharge[:],
+		EndChargeCap = existingcapcharge[:] - retcapcharge[:] + capcharge[:]
+	)
+	if setup["ParameterScale"] ==1
+		dfCap.StartCap = dfCap.StartCap * ModelScalingFactor
+		dfCap.RetCap = dfCap.RetCap * ModelScalingFactor
+		dfCap.NewCap = dfCap.NewCap * ModelScalingFactor
+		dfCap.EndCap = dfCap.EndCap * ModelScalingFactor
+		dfCap.StartEnergyCap = dfCap.StartEnergyCap * ModelScalingFactor
+		dfCap.RetEnergyCap = dfCap.RetEnergyCap * ModelScalingFactor
+		dfCap.NewEnergyCap = dfCap.NewEnergyCap * ModelScalingFactor
+		dfCap.EndEnergyCap = dfCap.EndEnergyCap * ModelScalingFactor
+		dfCap.StartChargeCap = dfCap.StartChargeCap * ModelScalingFactor
+		dfCap.RetChargeCap = dfCap.RetChargeCap * ModelScalingFactor
+		dfCap.NewChargeCap = dfCap.NewChargeCap * ModelScalingFactor
+		dfCap.EndChargeCap = dfCap.EndChargeCap * ModelScalingFactor
+	end
+	total = DataFrame(
+			Resource = "Total", Zone = "n/a",
+			StartCap = sum(dfCap[!,:StartCap]), RetCap = sum(dfCap[!,:RetCap]),
+			NewCap = sum(dfCap[!,:NewCap]), EndCap = sum(dfCap[!,:EndCap]),
+			StartEnergyCap = sum(dfCap[!,:StartEnergyCap]), RetEnergyCap = sum(dfCap[!,:RetEnergyCap]),
+			NewEnergyCap = sum(dfCap[!,:NewEnergyCap]), EndEnergyCap = sum(dfCap[!,:EndEnergyCap]),
+			StartChargeCap = sum(dfCap[!,:StartChargeCap]), RetChargeCap = sum(dfCap[!,:RetChargeCap]),
+			NewChargeCap = sum(dfCap[!,:NewChargeCap]), EndChargeCap = sum(dfCap[!,:EndChargeCap])
+		)
+
+	dfCap = vcat(dfCap, total)
+	CSV.write(joinpath(path, "capacity.csv"), dftranspose(dfCap, false), writeheader=false)
+	return dfCap
+end

--- a/src/GenX_extensions/write_capacityfactor.jl
+++ b/src/GenX_extensions/write_capacityfactor.jl
@@ -1,0 +1,27 @@
+@doc raw"""
+	write_capacityfactor(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+
+Function for writing the capacity factor of different resources.
+"""
+function write_capacityfactor(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+    dfGen = inputs["dfGen"]
+    G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
+    T = inputs["T"]     # Number of time steps (hours)
+    THERM_ALL = inputs["THERM_ALL"]
+    VRE = inputs["VRE"]
+    HYDRO_RES = inputs["HYDRO_RES"]
+    MUST_RUN = inputs["MUST_RUN"]
+
+    dfCapacityfactor = DataFrame(Resource=inputs["RESOURCES"], Zone=dfGen[!, :Zone], AnnualSum=zeros(G), Capacity=zeros(G), CapacityFactor=zeros(G))
+    scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
+    dfCapacityfactor.AnnualSum .= value.(EP[:vP]) * inputs["omega"] * scale_factor
+    dfCapacityfactor.Capacity .= value.(EP[:eTotalCap]) * scale_factor
+    # We only calcualte the resulted capacity factor with total capacity > 1MW and total generation > 1MWh
+    EXISTING = intersect(findall(x -> x >= 1, dfCapacityfactor.AnnualSum), findall(x -> x >= 1, dfCapacityfactor.Capacity))
+    # We calculate capacity factor for thermal, vre, hydro and must run. Not for storage and flexible demand
+    CF_GEN = intersect(union(THERM_ALL, VRE, HYDRO_RES, MUST_RUN), EXISTING)
+    dfCapacityfactor.CapacityFactor[CF_GEN] .= (dfCapacityfactor.AnnualSum[CF_GEN] ./ dfCapacityfactor.Capacity[CF_GEN]) / sum(inputs["omega"][t] for t in 1:T)
+
+    CSV.write(joinpath(path, "capacityfactor.csv"), dftranspose(dfCapacityfactor, false), writeheader=false)
+    return dfCapacityfactor
+end

--- a/src/GenX_extensions/write_charging_cost.jl
+++ b/src/GenX_extensions/write_charging_cost.jl
@@ -1,0 +1,21 @@
+function write_charging_cost(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	dfGen = inputs["dfGen"]
+	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
+	T = inputs["T"]     # Number of time steps (hours)
+	STOR_ALL = inputs["STOR_ALL"]
+	FLEX = inputs["FLEX"]
+	dfChargingcost = DataFrame(Region = dfGen[!, :region], Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone], Cluster = dfGen[!, :cluster], AnnualSum = Array{Float64}(undef, G),)
+	chargecost = zeros(G, T)
+	if !isempty(STOR_ALL)
+	    chargecost[STOR_ALL, :] .= (value.(EP[:vCHARGE][STOR_ALL, :]).data) .* transpose(dual.(EP[:cPowerBalance]) ./ inputs["omega"])[dfGen[STOR_ALL, :Zone], :]
+	end
+	if !isempty(FLEX)
+	    chargecost[FLEX, :] .= value.(EP[:vP][FLEX, :]) .* transpose(dual.(EP[:cPowerBalance]) ./ inputs["omega"])[dfGen[FLEX, :Zone], :]
+	end
+	if setup["ParameterScale"] == 1
+	    chargecost *= ModelScalingFactor^2
+	end
+	dfChargingcost.AnnualSum .= chargecost * inputs["omega"]
+	CSV.write(joinpath(path, "ChargingCost.csv"), dftranspose(dfChargingcost, false), writeheader=false)
+	return dfChargingcost
+end

--- a/src/GenX_extensions/write_energy_revenue.jl
+++ b/src/GenX_extensions/write_energy_revenue.jl
@@ -1,0 +1,24 @@
+@doc raw"""
+	write_energy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+
+Function for writing energy revenue from the different generation technologies.
+"""
+function write_energy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	dfGen = inputs["dfGen"]
+	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
+	T = inputs["T"]     # Number of time steps (hours)
+	FLEX = inputs["FLEX"]
+	NONFLEX = setdiff(collect(1:G), FLEX)
+	dfEnergyRevenue = DataFrame(Region = dfGen.region, Resource = inputs["RESOURCES"], Zone = dfGen.Zone, Cluster = dfGen.cluster, AnnualSum = Array{Float64}(undef, G),)
+	energyrevenue = zeros(G, T)
+	energyrevenue[NONFLEX, :] = value.(EP[:vP][NONFLEX, :]) .* transpose(dual.(EP[:cPowerBalance]) ./ inputs["omega"])[dfGen[NONFLEX, :Zone], :]
+	if !isempty(FLEX)
+		energyrevenue[FLEX, :] = value.(EP[:vCHARGE_FLEX][FLEX, :]).data .* transpose(dual.(EP[:cPowerBalance]) ./ inputs["omega"])[dfGen[FLEX, :Zone], :]
+	end
+	if setup["ParameterScale"] == 1
+		energyrevenue *= ModelScalingFactor^2
+	end
+	dfEnergyRevenue.AnnualSum .= energyrevenue * inputs["omega"]
+	CSV.write(joinpath(path, "EnergyRevenue.csv"),  dftranspose(dfEnergyRevenue, false), writeheader=false)
+	return dfEnergyRevenue
+end

--- a/src/GenX_extensions/write_net_revenue.jl
+++ b/src/GenX_extensions/write_net_revenue.jl
@@ -1,0 +1,122 @@
+@doc raw"""
+	write_net_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model, dfCap::DataFrame, dfESRRev::DataFrame, dfResRevenue::DataFrame, dfChargingcost::DataFrame, dfPower::DataFrame, dfEnergyRevenue::DataFrame, dfSubRevenue::DataFrame, dfRegSubRevenue::DataFrame)
+
+Function for writing net revenue of different generation technologies.
+"""
+function write_net_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model, dfCap::DataFrame, dfESRRev::DataFrame, dfResRevenue::DataFrame, dfChargingcost::DataFrame, dfPower::DataFrame, dfEnergyRevenue::DataFrame, dfSubRevenue::DataFrame, dfRegSubRevenue::DataFrame)
+	dfGen = inputs["dfGen"]
+	T = inputs["T"]     			# Number of time steps (hours)
+	Z = inputs["Z"]     			# Number of zones
+	G = inputs["G"]     			# Number of generators
+	COMMIT = inputs["COMMIT"]		# Thermal units for unit commitment
+	STOR_ALL = inputs["STOR_ALL"]
+
+	# Create a NetRevenue dataframe
+ 	dfNetRevenue = DataFrame(region = dfGen[!,:region], Resource = inputs["RESOURCES"], zone = dfGen[!,:Zone], Cluster = dfGen[!,:cluster], R_ID = dfGen[!,:R_ID])
+
+	# Add investment cost to the dataframe
+	dfNetRevenue.Inv_cost_MW = dfGen[!,:Inv_Cost_per_MWyr] .* dfCap[1:end-1,:NewCap]
+	dfNetRevenue.Inv_cost_MWh = dfGen[!,:Inv_Cost_per_MWhyr] .* dfCap[1:end-1,:NewEnergyCap]
+	if setup["ParameterScale"] == 1
+		dfNetRevenue.Inv_cost_MWh *= ModelScalingFactor # converting Million US$ to US$
+		dfNetRevenue.Inv_cost_MW *= ModelScalingFactor # converting Million US$ to US$
+	end
+
+	# Add operations and maintenance cost to the dataframe
+	dfNetRevenue.Fixed_OM_cost_MW = dfGen[!,:Fixed_OM_Cost_per_MWyr] .* dfCap[1:end-1,:EndCap]
+ 	dfNetRevenue.Fixed_OM_cost_MWh = dfGen[!,:Fixed_OM_Cost_per_MWhyr] .* dfCap[1:end-1,:EndEnergyCap]
+ 	dfNetRevenue.Var_OM_cost_out = (dfGen[!,:Var_OM_Cost_per_MWh]) .* dfPower[1:end-1,:AnnualSum]
+	if setup["ParameterScale"] == 1
+		dfNetRevenue.Fixed_OM_cost_MW *= ModelScalingFactor # converting Million US$ to US$
+		dfNetRevenue.Fixed_OM_cost_MWh *= ModelScalingFactor # converting Million US$ to US$
+		dfNetRevenue.Var_OM_cost_out *= ModelScalingFactor # converting Million US$ to US$
+	end
+
+	# Add fuel cost to the dataframe
+	dfNetRevenue.Fuel_cost = (inputs["C_Fuel_per_MWh"] .* value.(EP[:vP])) * inputs["omega"]
+	if setup["ParameterScale"] == 1
+		dfNetRevenue.Fuel_cost *= ModelScalingFactor^2 # converting Million US$ to US$
+	end
+
+	# Add storage cost to the dataframe
+	dfNetRevenue.Var_OM_cost_in = zeros(nrow(dfNetRevenue))
+	if !isempty(STOR_ALL)
+		dfNetRevenue.Var_OM_cost_in[STOR_ALL] = dfGen[STOR_ALL,:Var_OM_Cost_per_MWh_In] .* ((value.(EP[:vCHARGE][STOR_ALL,:]).data) * inputs["omega"])
+ 	end
+	if setup["ParameterScale"] == 1
+		dfNetRevenue.Var_OM_cost_in *= ModelScalingFactor^2 # converting Million US$ to US$
+	end
+	# Add start-up cost to the dataframe
+	dfNetRevenue.StartCost = zeros(nrow(dfNetRevenue))
+	if setup["UCommit"]>=1 && !isempty(COMMIT)
+		# if you don't use vec, dimension won't match
+		dfNetRevenue.StartCost[COMMIT] .= vec(sum(value.(EP[:eCStart][COMMIT, :]).data, dims = 2))
+ 	end
+	if setup["ParameterScale"] == 1
+		dfNetRevenue.StartCost *= ModelScalingFactor^2 # converting Million US$ to US$
+	end
+	# Add charge cost to the dataframe
+	dfNetRevenue.Charge_cost = zeros(nrow(dfNetRevenue))
+	if has_duals(EP) == 1
+		dfNetRevenue.Charge_cost = dfChargingcost[!,:AnnualSum] # Unit is confirmed to be US$
+	end
+
+	# Add energy and subsidy revenue to the dataframe
+	dfNetRevenue.EnergyRevenue = zeros(nrow(dfNetRevenue))
+	dfNetRevenue.SubsidyRevenue = zeros(nrow(dfNetRevenue))
+	if has_duals(EP) == 1
+		dfNetRevenue.EnergyRevenue = dfEnergyRevenue[!,:AnnualSum] # Unit is confirmed to be US$
+	 	dfNetRevenue.SubsidyRevenue = dfSubRevenue[!,:SubsidyRevenue] # Unit is confirmed to be US$
+	end
+
+	# Add capacity revenue to the dataframe
+	dfNetRevenue.ReserveMarginRevenue = zeros(nrow(dfNetRevenue))
+ 	if setup["CapacityReserveMargin"] > 0 && has_duals(EP) == 1 # The unit is confirmed to be $
+ 		dfNetRevenue.ReserveMarginRevenue = dfResRevenue[!,:AnnualSum]
+ 	end
+
+	# Add RPS/CES revenue to the dataframe
+	dfNetRevenue.ESRRevenue = zeros(nrow(dfNetRevenue))
+ 	if setup["EnergyShareRequirement"] > 0 && has_duals(EP) == 1 # The unit is confirmed to be $
+ 		dfNetRevenue.ESRRevenue = dfESRRev[!,:AnnualSum]
+ 	end
+
+	# Calculate emissions cost
+	dfNetRevenue.EmissionsCost = zeros(nrow(dfNetRevenue))
+	if setup["CO2Cap"] >=1 && has_duals(EP) == 1
+		for cap in 1:inputs["NCO2Cap"]
+			co2_cap_dual = dual(EP[:cCO2Emissions_systemwide][cap])
+			CO2ZONES = findall(x->x==1, inputs["dfCO2CapZones"][:,cap])
+			GEN_IN_ZONE = dfGen[[y in CO2ZONES for y in dfGen[:, :Zone]], :R_ID]
+			if setup["CO2Cap"]==1 # Mass-based
+				# Cost = sum(sum(emissions of gen y * dual(CO2 constraint[cap]) for z in Z) for cap in setup["NCO2"])
+				temp_vec = value.(EP[:eEmissionsByPlant][GEN_IN_ZONE, :]) * inputs["omega"]
+				dfNetRevenue.EmissionsCost[GEN_IN_ZONE] += - co2_cap_dual * temp_vec
+			elseif setup["CO2Cap"]==2 # Demand + Rate-based
+				# Cost = sum(sum(emissions for zone z * dual(CO2 constraint[cap]) for z in Z) for cap in setup["NCO2"])
+				temp_vec = value.(EP[:eEmissionsByPlant][GEN_IN_ZONE, :]) * inputs["omega"]
+				dfNetRevenue.EmissionsCost[GEN_IN_ZONE] += - co2_cap_dual * temp_vec
+			elseif setup["CO2Cap"]==3 # Generation + Rate-based
+				SET_WITH_MAXCO2RATE = union(inputs["THERM_ALL"],inputs["VRE"], inputs["VRE"],inputs["MUST_RUN"],inputs["HYDRO_RES"])
+				Y = intersect(GEN_IN_ZONE, SET_WITH_MAXCO2RATE)
+				temp_vec = (value.(EP[:eEmissionsByPlant][Y,:]) - (value.(EP[:vP][Y,:]) .* inputs["dfMaxCO2Rate"][dfGen[Y, :Zone], cap])) * inputs["omega"]
+				dfNetRevenue.EmissionsCost[Y] += - co2_cap_dual * temp_vec
+			end
+		end
+		if setup["ParameterScale"] == 1
+			dfNetRevenue.EmissionsCost *= ModelScalingFactor^2 # converting Million US$ to US$
+		end
+	end
+
+	# Add regional technology subsidy revenue to the dataframe
+	dfNetRevenue.RegSubsidyRevenue = zeros(nrow(dfNetRevenue))
+	if setup["MinCapReq"] >= 1 && has_duals(EP) == 1 # The unit is confirmed to be US$
+		dfNetRevenue.RegSubsidyRevenue = dfRegSubRevenue[!,:SubsidyRevenue]
+	end
+
+	dfNetRevenue.Revenue = dfNetRevenue.EnergyRevenue .+ dfNetRevenue.SubsidyRevenue .+ dfNetRevenue.ReserveMarginRevenue .+ dfNetRevenue.ESRRevenue .+ dfNetRevenue.RegSubsidyRevenue
+	dfNetRevenue.Cost = dfNetRevenue.Inv_cost_MW .+ dfNetRevenue.Inv_cost_MWh .+ dfNetRevenue.Fixed_OM_cost_MW .+ dfNetRevenue.Fixed_OM_cost_MWh .+ dfNetRevenue.Var_OM_cost_out .+ dfNetRevenue.Var_OM_cost_in .+ dfNetRevenue.Fuel_cost .+ dfNetRevenue.Charge_cost .+ dfNetRevenue.EmissionsCost .+ dfNetRevenue.StartCost
+	dfNetRevenue.Profit = dfNetRevenue.Revenue .- dfNetRevenue.Cost
+
+	CSV.write(joinpath(path, "NetRevenue.csv"), dftranspose(dfNetRevenue, false), writeheader=false)
+end

--- a/src/GenX_extensions/write_price.jl
+++ b/src/GenX_extensions/write_price.jl
@@ -1,0 +1,25 @@
+@doc raw"""
+	write_price(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+
+Function for reporting marginal electricity price for each model zone and time step. Marginal electricity price is equal to the dual variable of the load balance constraint. If GenX is configured as a mixed integer linear program, then this output is only generated if `WriteShadowPrices` flag is activated. If configured as a linear program (i.e. linearized unit commitment or economic dispatch) then output automatically available.
+"""
+function write_price(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	T = inputs["T"]     # Number of time steps (hours)
+	Z = inputs["Z"]     # Number of zones
+
+	## Extract dual variables of constraints
+	# Electricity price: Dual variable of hourly power balance constraint = hourly price
+	dfPrice = DataFrame(Zone = 1:Z) # The unit is $/MWh
+	scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
+	# Dividing dual variable for each hour with corresponding hourly weight to retrieve marginal cost of generation
+	dfPrice = hcat(dfPrice, DataFrame(AnnualMean=Array{Union{Missing,Float32}}(undef, Z)), DataFrame(transpose(dual.(EP[:cPowerBalance])./inputs["omega"]*scale_factor), :auto))
+
+	auxNew_Names=[Symbol("Zone");Symbol("AnnualMean");[Symbol("t$t") for t in 1:T]]
+	rename!(dfPrice,auxNew_Names)
+
+        dfPrice.AnnualMean .= [sum(dfPrice[i, r"t"])/T for i in 1:Z]
+
+	## Linear configuration final output
+	CSV.write(joinpath(path, "prices.csv"), dftranspose(dfPrice, false), writeheader=false)
+	return dfPrice
+end

--- a/src/GenX_extensions/write_reliability.jl
+++ b/src/GenX_extensions/write_reliability.jl
@@ -1,0 +1,23 @@
+@doc raw"""
+	write_reliability(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+
+Function for reporting dual variable of maximum non-served energy constraint (shadow price of reliability constraint) for each model zone and time step.
+"""
+function write_reliability(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	T = inputs["T"]     # Number of time steps (hours)
+	Z = inputs["Z"]     # Number of zones
+
+	# reliability: Dual variable of maximum NSE constraint = shadow value of reliability constraint
+	dfReliability = DataFrame(Zone = 1:Z)
+	# Dividing dual variable for each hour with corresponding hourly weight to retrieve marginal cost of generation
+	scale_factor = setup["ParameterScale"] == 1 ? ModelScalingFactor : 1
+	dfReliability = hcat(dfReliability, DataFrame(AnnualMean=Array{Union{Missing,Float32}}(undef, Z)), DataFrame(transpose(dual.(EP[:cMaxNSE])./inputs["omega"]*scale_factor), :auto))
+
+	auxNew_Names=[Symbol("Zone");Symbol("AnnualMean");[Symbol("t$t") for t in 1:T]]
+	rename!(dfReliability,auxNew_Names)
+
+        dfReliability.AnnualMean .= [sum(dfReliability[i, r"t"])/T for i in 1:Z] 
+
+	CSV.write(joinpath(path, "reliability.csv"), dftranspose(dfReliability, false), writeheader=false)
+
+end

--- a/src/GenX_extensions/write_storage.jl
+++ b/src/GenX_extensions/write_storage.jl
@@ -1,0 +1,36 @@
+@doc raw"""
+	write_storage(path::AbstractString, inputs::Dict,setup::Dict, EP::Model)
+
+Function for writing the capacities of different storage technologies, including hydro reservoir, flexible storage tech etc.
+"""
+function write_storage(path::AbstractString, inputs::Dict,setup::Dict, EP::Model)
+	dfGen = inputs["dfGen"]
+	T = inputs["T"]     # Number of time steps (hours)
+	G = inputs["G"]
+	STOR_ALL = inputs["STOR_ALL"]
+	HYDRO_RES = inputs["HYDRO_RES"]
+	FLEX = inputs["FLEX"]
+	# Storage level (state of charge) of each resource in each time step
+	dfStorage = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!,:Zone])
+	storagevcapvalue = zeros(G,T)
+
+	if !isempty(inputs["STOR_ALL"])
+	    storagevcapvalue[STOR_ALL, :] = value.(EP[:vS][STOR_ALL, :])
+	end
+	if !isempty(inputs["HYDRO_RES"])
+	    storagevcapvalue[HYDRO_RES, :] = value.(EP[:vS_HYDRO][HYDRO_RES, :])
+	end
+	if !isempty(inputs["FLEX"])
+	    storagevcapvalue[FLEX, :] = value.(EP[:vS_FLEX][FLEX, :])
+	end
+	if setup["ParameterScale"] == 1
+	    storagevcapvalue *= ModelScalingFactor
+	end
+
+	dfStorage = hcat(dfStorage, DataFrame(AnnualMean=Array{Union{Missing,Float32}}(undef, G)), DataFrame(storagevcapvalue, :auto))
+	auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualMean");[Symbol("t$t") for t in 1:T]]
+	rename!(dfStorage,auxNew_Names)
+
+        dfStorage.AnnualMean .= [sum(dfStorage[i,r"t"])/T for i in 1:G]
+	CSV.write(joinpath(path, "storage.csv"), dftranspose(dfStorage, false), writeheader=false)
+end

--- a/src/GenX_extensions/write_storagedual.jl
+++ b/src/GenX_extensions/write_storagedual.jl
@@ -1,0 +1,45 @@
+@doc raw"""
+	write_storagedual(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+
+Function for reporting dual of storage level (state of charge) balance of each resource in each time step.
+"""
+function write_storagedual(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	dfGen = inputs["dfGen"]
+
+	G = inputs["G"]     # Number of resources (generators, storage, DR, and DERs)
+	T = inputs["T"]     # Number of time steps (hours)
+
+	START_SUBPERIODS = inputs["START_SUBPERIODS"]
+	INTERIOR_SUBPERIODS = inputs["INTERIOR_SUBPERIODS"]
+	REP_PERIOD = inputs["REP_PERIOD"]
+	STOR_ALL = inputs["STOR_ALL"]
+	hours_per_subperiod = inputs["hours_per_subperiod"] #total number of hours per subperiod
+
+	# # Dual of storage level (state of charge) balance of each resource in each time step
+	dfStorageDual = DataFrame(Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone])
+	dual_values = zeros(G, T)
+
+	# Loop over W separately hours_per_subperiod
+	STOR_ALL_NONLDS = setdiff(STOR_ALL, inputs["STOR_LONG_DURATION"])
+	STOR_ALL_LDS = intersect(STOR_ALL, inputs["STOR_LONG_DURATION"])
+	dual_values[STOR_ALL, INTERIOR_SUBPERIODS] = (dual.(EP[:cSoCBalInterior][INTERIOR_SUBPERIODS, STOR_ALL]).data ./ inputs["omega"][INTERIOR_SUBPERIODS])'
+	dual_values[STOR_ALL_NONLDS, START_SUBPERIODS] = (dual.(EP[:cSoCBalStart][START_SUBPERIODS, STOR_ALL_NONLDS]).data ./ inputs["omega"][START_SUBPERIODS])'
+	if !isempty(STOR_ALL_LDS)
+		if inputs["REP_PERIOD"] > 1
+			dual_values[STOR_ALL_LDS, START_SUBPERIODS] = (dual.(EP[:cSoCBalLongDurationStorageStart][1:REP_PERIOD, STOR_ALL_LDS]).data ./ inputs["omega"][START_SUBPERIODS])'
+		else
+			dual_values[STOR_ALL_LDS, START_SUBPERIODS] = (dual.(EP[:cSoCBalStart][START_SUBPERIODS, STOR_ALL_LDS]).data ./ inputs["omega"][START_SUBPERIODS])'
+		end
+	end
+
+	if setup["ParameterScale"] == 1
+	    dual_values *= ModelScalingFactor
+	end
+
+	dfStorageDual=hcat(dfStorageDual, DataFrame(AnnualMean=Array{Union{Missing,Float32}}(undef, G)), DataFrame(dual_values, :auto))
+	rename!(dfStorageDual,[Symbol("Resource");Symbol("Zone");Symbol("AnnualMean");[Symbol("t$t") for t in 1:T]])
+
+        dfStorageDual.AnnualMean .= [sum(dfStorageDual[i,r"t"])/T for i in 1:G]
+
+	CSV.write(joinpath(path, "storagebal_duals.csv"), dftranspose(dfStorageDual, false), writeheader=false)
+end

--- a/src/GenX_extensions/write_subsidy_revenue.jl
+++ b/src/GenX_extensions/write_subsidy_revenue.jl
@@ -1,0 +1,30 @@
+@doc raw"""
+	write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+
+Function for reporting subsidy revenue earned if a generator specified `Min_Cap` is provided in the input file, or if a generator is subject to a Minimum Capacity Requirement constraint. The unit is \$.
+"""
+function write_subsidy_revenue(path::AbstractString, inputs::Dict, setup::Dict, EP::Model)
+	dfGen = inputs["dfGen"]
+	G = inputs["G"]
+
+	dfSubRevenue = DataFrame(Region = dfGen[!, :region], Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone], Cluster = dfGen[!, :cluster], R_ID=dfGen[!, :R_ID], SubsidyRevenue = zeros(G))
+	MIN_CAP = dfGen[(dfGen[!, :Min_Cap_MW].>0), :R_ID]
+	dfSubRevenue.SubsidyRevenue[MIN_CAP] .= (value.(EP[:eTotalCap])[MIN_CAP]) .* (dual.(EP[:cMinCap][MIN_CAP])).data
+	### calculating tech specific subsidy revenue
+	dfRegSubRevenue = DataFrame(Region = dfGen[!, :region], Resource = inputs["RESOURCES"], Zone = dfGen[!, :Zone], Cluster = dfGen[!, :cluster], R_ID=dfGen[!, :R_ID], SubsidyRevenue = zeros(G))
+	if (setup["MinCapReq"] >= 1)
+		for mincap in 1:inputs["NumberOfMinCapReqs"] # This key only exists if MinCapReq >= 1, so we can't get it at the top outside of this condition.
+			MIN_CAP_GEN = dfGen[(dfGen[!, Symbol("MinCapTag_$mincap")].==1), :R_ID]
+			dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN] .= dfRegSubRevenue.SubsidyRevenue[MIN_CAP_GEN] + (value.(EP[:eTotalCap][MIN_CAP_GEN])) * (dual.(EP[:cZoneMinCapReq][mincap]))
+		end
+	end
+
+	if setup["ParameterScale"] == 1
+		dfSubRevenue.SubsidyRevenue *= ModelScalingFactor^2 #convert from Million US$ to US$
+		dfRegSubRevenue.SubsidyRevenue *= ModelScalingFactor^2 #convert from Million US$ to US$
+	end
+
+	CSV.write(joinpath(path, "SubsidyRevenue.csv"), dftranspose(dfSubRevenue, false), writeheader=false)
+	CSV.write(joinpath(path, "RegSubsidyRevenue.csv"), dftranspose(dfRegSubRevenue, false), writeheader=false)
+	return dfSubRevenue, dfRegSubRevenue
+end

--- a/src/HSC/write_outputs/write_g2p_capacity.jl
+++ b/src/HSC/write_outputs/write_g2p_capacity.jl
@@ -57,6 +57,6 @@ function write_g2p_capacity(path::AbstractString, sep::AbstractString, inputs::D
         )
 
     dfCap = vcat(dfCap, total)
-    CSV.write(joinpath(path, "HSC_g2p_capacity.csv"), dfCap)
+    CSV.write(joinpath(path, "HSC_g2p_capacity.csv"), dftranspose(dfCap, false), writeheader=false)
     return dfCap
 end

--- a/src/HSC/write_outputs/write_h2_capacity.jl
+++ b/src/HSC/write_outputs/write_h2_capacity.jl
@@ -97,6 +97,6 @@ function write_h2_capacity(path::AbstractString, sep::AbstractString, inputs::Di
     )
 
     dfCap = vcat(dfCap, total)
-    CSV.write(joinpath(path, "HSC_generation_storage_capacity.csv"), dfCap)
+    CSV.write(joinpath(path, "HSC_generation_storage_capacity.csv"), dftranspose(dfCap, false), writeheader=false)
     return dfCap
 end

--- a/src/HSC/write_outputs/write_h2_storage.jl
+++ b/src/HSC/write_outputs/write_h2_storage.jl
@@ -41,8 +41,13 @@ function write_h2_storage(path::AbstractString, sep::AbstractString, inputs::Dic
         storagevcapvalue[y,:] = s[y,:]
     end
 
-    dfH2Storage = hcat(dfH2Storage, DataFrame(storagevcapvalue, :auto))
-    auxNew_Names=[Symbol("Resource");Symbol("Zone");[Symbol("t$t") for t in 1:T]]
+    dfH2Storage = hcat(dfH2Storage, DataFrame(AnnualMean=Array{Union{Missing,Float32}}(undef, H)), DataFrame(storagevcapvalue, :auto))
+
+    auxNew_Names=[Symbol("Resource");Symbol("Zone");Symbol("AnnualMean");[Symbol("t$t") for t in 1:T]]
+
     rename!(dfH2Storage,auxNew_Names)
-    CSV.write(joinpath(path, "storage.csv"), dftranspose(dfH2Storage, false), writeheader=false)
+
+    dfH2Storage.AnnualMean .= [sum(dfH2Storage[i,r"t"])/T for i in 1:H ]
+
+    CSV.write(joinpath(path, "HSC_storage.csv"), dftranspose(dfH2Storage, false), writeheader=false)
 end

--- a/src/HSC/write_outputs/write_h2_truck_capacity.jl
+++ b/src/HSC/write_outputs/write_h2_truck_capacity.jl
@@ -95,5 +95,6 @@ function write_h2_truck_capacity(path::AbstractString, sep::AbstractString, inpu
     end
 
     dfH2TruckCap = vcat(dfH2TruckCap, dfH2TruckTotal)
-    CSV.write(string(path, sep, "h2_truck_capacity.csv"), dftranspose(dfH2TruckCap, false))
+    
+    CSV.write(string(path, sep, "HSC_h2_truck_capacity.csv"), dftranspose(dfH2TruckCap, false))
 end


### PR DESCRIPTION
# Description

Output files for GenX and HSC have been modified to have the standard format in their CSV results files.  The standard format follows the rule that users generally see in this order starting from the top row: Resources, Zone, AnnualSum/AnnualMean, and other attributes.  It also depends on the content of the file so that some files may not need to have exactly this format.

Here is an example of what a standard format looks like taken from power.csv:
<img width="854" alt="Screenshot 2023-10-10 at 11 21 38 AM" src="https://github.com/macroenergy/DOLPHYN/assets/2174909/6f105851-905c-4b30-a844-f83ba854ad21">

Any GenX output files that have been changed for the standard format purpose have been added to src/GenX_extensions.  Documentation is not up to date with these new additions to GenX_extensions.  

These are the files that have changes:
src/GenX_extensions/write_capacity.jl
src/GenX_extensions/write_capacityfactor.jl
src/GenX_extensions/write_charging_cost.jl
src/GenX_extensions/write_energy_revenue.jl
src/GenX_extensions/write_net_revenue.jl
src/GenX_extensions/write_price.jl
src/GenX_extensions/write_reliability.jl
src/GenX_extensions/write_storage.jl
src/GenX_extensions/write_storagedual.jl
src/GenX_extensions/write_subsidy_revenue.jl
src/HSC/write_outputs/write_g2p_capacity.jl
src/HSC/write_outputs/write_h2_capacity.jl
src/HSC/write_outputs/write_h2_storage.jl
src/HSC/write_outputs/write_h2_truck_capacity.jl

## Type of change

Please delete options that are not relevant.

- [x] Both fix and features changes that include GenX-side output files
- [x] This change needs a documentation update but not sure it is necessary for the merge; it generates warnings about documentation. See below. 

## Warnings
Warnings are generated. Here is one example:
````
WARNING: Method definition write_capacity(AbstractString, Base.Dict{K, V} where V where K, Base.Dict{K, V} where V where K, JuMP.GenericModel{Float64}) in module DOLPHYN at /Users/mbennett/projects/standard_format/release/DOLPHYN/src/GenX/src/write_outputs/write_capacity.jl:6 overwritten at /Users/mbennett/projects/standard_format/release/DOLPHYN/src/GenX_extensions/write_capacity.jl:6.
  ** incremental compilation may be fatally broken for this module **

┌ Warning: Replacing docs for `DOLPHYN.write_capacity :: Tuple{AbstractString, Dict, Dict, JuMP.Model}` in module `DOLPHYN`
└ @ Base.Docs docs/Docs.jl:240
WARNING: Method definition write_capacityfactor(AbstractString, Base.Dict{K, V} where V where K, Base.Dict{K, V} where V where K, JuMP.GenericModel{Float64}) in module DOLPHYN at /Users/mbennett/projects/standard_format/release/DOLPHYN/src/GenX/src/write_outputs/write_capacityfactor.jl:6 overwritten at /Users/mbennett/projects/standard_format/release/DOLPHYN/src/GenX_extensions/write_capacityfactor.jl:6.
  ** incremental compilation may be fatally broken for this module **
````
# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Example_Systems/SmallNewEngland/OneZone 
- [x] Example_Systems/SmallNewEngland/ThreeZones

**Test Configuration**:
* OS:  MacBook Pro Ventura 13.6
* Solver: Gurobi
* Julia version: 1.6.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate new warnings; see above under Warning
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [x] I have run tests with my code to avoid compatibility issues
- [] Any dependent changes have been merged and published in downstream modules
