### PR TITLE
CompatHelper: bump compat for Clustering to 0.15, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [compat]
 BenchmarkTools = "1.3.0"
 CSV = "0.10.0"
-Clustering = "0.14.0"
+Clustering = "0.14.0, 0.15"
 Combinatorics = "1.0.0"
 DataFrames = "1.3.5"
 DataStructures = "0.18.0"


### PR DESCRIPTION
# Description

Update compat of Clustering 

## Fixes issue \#

No associated issue

## Type of change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Example_Systems/SmallNewEngland/OneZone 
- [x] Example_Systems/SmallNewEngland/ThreeZones
