### PR TITLE
Load TDR data based on checking whether the file of interest exists, instead of all TDR files

### DIFF
--- a/src/CSC/load_inputs/load_co2_capture_DAC_variability.jl
+++ b/src/CSC/load_inputs/load_co2_capture_DAC_variability.jl
@@ -24,7 +24,7 @@ function load_co2_capture_DAC_variability(setup::Dict, path::AbstractString, sep
 	# Hourly capacity factors
 	#data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
 	data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) && isfile(joinpath(data_directory,"HSC_load_data.csv")) && isfile(joinpath(data_directory,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory,"CSC_capture_variability.csv")) # Use Time Domain Reduced data for GenX
+	if setup["TimeDomainReduction"] == 1 && isfile(joinpath(data_directory,"CSC_capture_variability.csv")) # Use Time Domain Reduced data for GenX
 		capture_var = DataFrame(CSV.File(string(joinpath(data_directory,"CSC_capture_variability.csv")), header=true), copycols=true)
 	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
 		capture_var = DataFrame(CSV.File(string(path,sep,"CSC_capture_variability.csv"), header=true), copycols=true)

--- a/src/HSC/load_inputs/load_h2_demand.jl
+++ b/src/HSC/load_inputs/load_h2_demand.jl
@@ -26,7 +26,7 @@ function load_h2_demand(setup::Dict, path::AbstractString, sep::AbstractString, 
 
     data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
     
-    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) && isfile(joinpath(data_directory,"HSC_load_data.csv")) && isfile(joinpath(data_directory,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory,"HSC_g2p_variability.csv")) # Use Time Domain Reduced data for GenX
+    if setup["TimeDomainReduction"] == 1 && isfile(joinpath(data_directory,"HSC_load_data.csv")) # Use Time Domain Reduced data for GenX
         H2_load_in = DataFrame(CSV.File(string(joinpath(data_directory,"HSC_load_data.csv")), header=true), copycols=true)
     else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
         H2_load_in = DataFrame(CSV.File(joinpath(path, "HSC_load_data.csv"), header=true), copycols=true)

--- a/src/HSC/load_inputs/load_h2_demand_liquid.jl
+++ b/src/HSC/load_inputs/load_h2_demand_liquid.jl
@@ -22,7 +22,7 @@ Function for reading input parameters related to liquid hydrogen load (demand) o
 function load_h2_demand_liquid(setup::Dict, path::AbstractString, sep::AbstractString, inputs_load::Dict)
     
     data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) && isfile(joinpath(data_directory,"HSC_load_data_liquid.csv")) && isfile(joinpath(data_directory,"HSC_generators_variability.csv")) # Use Time Domain Reduced data for GenX
+    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"HSC_load_data_liquid.csv")) # Use Time Domain Reduced data for GenX
         H2_load_in = DataFrame(CSV.File(joinpath(data_directory,"HSC_load_data_liquid.csv"), header=true), copycols=true)
     else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
         H2_load_in = DataFrame(CSV.File(joinpath(path, "HSC_load_data_liquid.csv"), header=true), copycols=true)

--- a/src/HSC/load_inputs/load_h2_g2p_variability.jl
+++ b/src/HSC/load_inputs/load_h2_g2p_variability.jl
@@ -24,7 +24,7 @@ function load_h2_g2p_variability(setup::Dict, path::AbstractString, sep::Abstrac
     # Hourly capacity factors
     #data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
     data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) && isfile(joinpath(data_directory,"HSC_load_data.csv")) && isfile(joinpath(data_directory,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory,"HSC_g2p_variability.csv")) # Use Time Domain Reduced data for GenX
+    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"HSC_g2p_variability.csv")) # Use Time Domain Reduced data for GenX
         gen_var = DataFrame(CSV.File(string(joinpath(data_directory,"HSC_g2p_variability.csv")), header=true), copycols=true)
     else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
         gen_var = DataFrame(CSV.File(joinpath(path, "HSC_g2p_variability.csv"), header=true), copycols=true)

--- a/src/HSC/load_inputs/load_h2_generators_variability.jl
+++ b/src/HSC/load_inputs/load_h2_generators_variability.jl
@@ -24,7 +24,7 @@ function load_h2_generators_variability(setup::Dict, path::AbstractString, sep::
     # Hourly capacity factors
     #data_directory = chop(replace(path, pwd() => ""), head = 1, tail = 0)
     data_directory = joinpath(path, setup["TimeDomainReductionFolder"])
-    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"Load_data.csv")) && isfile(joinpath(data_directory,"Generators_variability.csv")) && isfile(joinpath(data_directory,"Fuels_data.csv")) && isfile(joinpath(data_directory,"HSC_load_data.csv")) && isfile(joinpath(data_directory,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory,"HSC_g2p_variability.csv"))  # Use Time Domain Reduced data for GenX
+    if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory,"HSC_generators_variability.csv")) # Use Time Domain Reduced data for GenX
         gen_var = DataFrame(CSV.File(string(joinpath(data_directory,"HSC_generators_variability.csv")), header=true), copycols=true)
     else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
         gen_var = DataFrame(CSV.File(joinpath(path, "HSC_generators_variability.csv"), header=true), copycols=true)

--- a/src/LFSC/load_inputs/load_liquid_fuel_demand.jl
+++ b/src/LFSC/load_inputs/load_liquid_fuel_demand.jl
@@ -22,7 +22,7 @@ Function for reading input parameters related to liquid fuel load (demand) and e
 function load_liquid_fuel_demand(setup::Dict, path::AbstractString, sep::AbstractString, inputs::Dict)
     
 	data_directory_diesel = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory_diesel,"Load_data.csv")) && isfile(joinpath(data_directory_diesel,"Generators_variability.csv")) && isfile(joinpath(data_directory_diesel,"Fuels_data.csv")) && isfile(joinpath(data_directory_diesel,"HSC_load_data.csv")) && isfile(joinpath(data_directory_diesel,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory_diesel,"Liquid_Fuels_Diesel_Demand.csv")) # Use Time Domain Reduced data for GenX
+	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory_diesel,"Liquid_Fuels_Diesel_Demand.csv")) # Use Time Domain Reduced data for GenX
 		Liquid_Fuels_Diesel_demand_in = DataFrame(CSV.File(string(joinpath(data_directory_diesel,"Liquid_Fuels_Diesel_Demand.csv")), header=true), copycols=true)
 	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
 		Liquid_Fuels_Diesel_demand_in = DataFrame(CSV.File(string(path,sep,"Liquid_Fuels_Diesel_Demand.csv"), header=true), copycols=true)
@@ -45,7 +45,7 @@ function load_liquid_fuel_demand(setup::Dict, path::AbstractString, sep::Abstrac
 	###########################################################################################################################################
 
 	data_directory_jetfuel = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory_jetfuel,"Load_data.csv")) && isfile(joinpath(data_directory_jetfuel,"Generators_variability.csv")) && isfile(joinpath(data_directory_jetfuel,"Fuels_data.csv")) && isfile(joinpath(data_directory_jetfuel,"HSC_load_data.csv")) && isfile(joinpath(data_directory_jetfuel,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory_jetfuel,"Liquid_Fuels_Jetfuel_Demand.csv")) # Use Time Domain Reduced data for GenX
+	if setup["TimeDomainReduction"] == 1 && isfile(joinpath(data_directory_jetfuel,"Liquid_Fuels_Jetfuel_Demand.csv")) # Use Time Domain Reduced data for GenX
 		Liquid_Fuels_Jetfuel_demand_in = DataFrame(CSV.File(string(joinpath(data_directory_jetfuel,"Liquid_Fuels_Jetfuel_Demand.csv")), header=true), copycols=true)
 	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
 		Liquid_Fuels_Jetfuel_demand_in = DataFrame(CSV.File(string(path,sep,"Liquid_Fuels_Jetfuel_Demand.csv"), header=true), copycols=true)
@@ -68,7 +68,7 @@ function load_liquid_fuel_demand(setup::Dict, path::AbstractString, sep::Abstrac
 	###########################################################################################################################################
 
 	data_directory_gasoline = joinpath(path, setup["TimeDomainReductionFolder"])
-	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory_gasoline,"Load_data.csv")) && isfile(joinpath(data_directory_gasoline,"Generators_variability.csv")) && isfile(joinpath(data_directory_gasoline,"Fuels_data.csv")) && isfile(joinpath(data_directory_gasoline,"HSC_load_data.csv")) && isfile(joinpath(data_directory_gasoline,"HSC_generators_variability.csv")) && isfile(joinpath(data_directory_gasoline,"Liquid_Fuels_Gasoline_Demand.csv")) # Use Time Domain Reduced data for GenX
+	if setup["TimeDomainReduction"] == 1  && isfile(joinpath(data_directory_gasoline,"Liquid_Fuels_Gasoline_Demand.csv")) # Use Time Domain Reduced data for GenX
 		Liquid_Fuels_Gasoline_Demand_in = DataFrame(CSV.File(string(joinpath(data_directory_gasoline,"Liquid_Fuels_Gasoline_Demand.csv")), header=true), copycols=true)
 	else # Run without Time Domain Reduction OR Getting original input data for Time Domain Reduction
 		Liquid_Fuels_Gasoline_Demand_in = DataFrame(CSV.File(string(path,sep,"Liquid_Fuels_Gasoline_Demand.csv"), header=true), copycols=true)


### PR DESCRIPTION
…not all TDR files

# Description

Dolphyn only loads TDR inputs if all TDR files are present instead of just the file of interest. This check isn't consistent, as the list of "all" TDR files is different in different places. This PR changes the check to only be based on the TDR flag and whether the file of interest exists

## Fixes issue \#

#222 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Example_Systems/SmallNewEngland/OneZone 
- [x] Example_Systems/SmallNewEngland/ThreeZones

**Test Configuration**:
* OS: MacOS M2
* Solver: Gurobi
* Julia version: 1.9.3
* Solver version: 10.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run tests with my code to avoid compatibility issues
- [x] Any dependent changes have been merged and published in downstream modules
