### PR TITLE
Speed up writing HSC and LFSC duals

### DIFF
--- a/src/HSC/write_outputs/write_h2_balance_dual.jl
+++ b/src/HSC/write_outputs/write_h2_balance_dual.jl
@@ -19,27 +19,12 @@ function write_h2_balance_dual(path::AbstractString, sep::AbstractString, inputs
 	T = inputs["T"]     # Number of time steps (hours)
 	Z = inputs["Z"]     # Number of zones
 
+	omega = inputs["omega"] # Time step weights
+	setup["ParameterScale"]==1 ? SCALING = ModelScalingFactor : SCALING = 1.0
+
 	# # Dual of storage level (state of charge) balance of each resource in each time step
 	dfH2BalanceDual = DataFrame(Zone = 1:Z)
-	# Define an empty array
-	x1 = Array{Float64}(undef, Z, T)
-	dual_values =Array{Float64}(undef, Z, T)
-
-	# Loop over W separately hours_per_subperiod
-	for z in 1:Z
-		for t in 1:T
-			x1[z,t] = dual.(EP[:cH2Balance])[t,z] #Use this for getting dual values and put in the extracted codes from PJM
-		end
-	end
-
-	# Incorporating effect of time step weights (When OperationWrapping=1) and Parameter scaling (ParameterScale=1) on dual variables
-	for z in 1:Z
-		if setup["ParameterScale"]==1
-			dual_values[z,:] = x1[z,:]./inputs["omega"] *ModelScalingFactor
-		else
-			dual_values[z,:] = x1[z,:]./inputs["omega"]
-		end
-	end
+	dual_values = transpose(dual.(EP[:cH2Balance]) ./ omega) .* SCALING
 
 	dfH2BalanceDual=hcat(dfH2BalanceDual, DataFrame(dual_values, :auto))
 	rename!(dfH2BalanceDual,[Symbol("Zone");[Symbol("t$t") for t in 1:T]])

--- a/src/LFSC/write_outputs/write_liquid_fuel_balance_dual.jl
+++ b/src/LFSC/write_outputs/write_liquid_fuel_balance_dual.jl
@@ -1,19 +1,3 @@
-""""
-DOLPHYN: Decision Optimization for Low-carbon Power and Hydrogen Networks
-Copyright (C) 2022,  Massachusetts Institute of Technology
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-A complete copy of the GNU General Public License v2 (GPLv2) is available
-in LICENSE.txt.  Users uncompressing this from an archive may not have
-received this license file.  If not, see <http://www.gnu.org/licenses/>.
-"""
-
 @doc raw"""
 	write_liquid_fuel_balance_dual(path::AbstractString, sep::AbstractString, inputs::Dict, setup::Dict, EP::Model)
 
@@ -24,27 +8,15 @@ function write_liquid_fuel_balance_dual(path::AbstractString, sep::AbstractStrin
 	T = inputs["T"]     # Number of time steps (hours)
 	Z = inputs["Z"]     # Number of zones
 
+	omega = inputs["omega"] # Time step weights
+	setup["ParameterScale"]==1 ? SCALING = ModelScalingFactor : SCALING = 1.0
+
 	# # Dual of storage level (state of charge) balance of each resource in each time step
 	dfDieselBalanceDual = DataFrame(Zone = 1:Z)
 	# Define an empty array
-	x1 = Array{Float64}(undef, Z, T)
-	dual_values =Array{Float64}(undef, Z, T)
-
-	# Loop over W separately hours_per_subperiod
-	for z in 1:Z
-		for t in 1:T
-			x1[z,t] = dual.(EP[:cLFAnnualDieselBalance]) #Use this for getting dual values and put in the extracted codes from PJM
-		end
-	end
-
-	# Incorporating effect of time step weights (When OperationWrapping=1) and Parameter scaling (ParameterScale=1) on dual variables
-	for z in 1:Z
-		if setup["ParameterScale"]==1
-			dual_values[z,:] = x1[z,:]./inputs["omega"] *ModelScalingFactor
-		else
-			dual_values[z,:] = x1[z,:]./inputs["omega"]
-		end
-	end
+	dual_values = Array{Float64}(undef, Z, T)
+	dual_values .= dual(EP[:cLFAnnualDieselBalance]) * SCALING
+	dual_values ./= transpose(omega)
 
 	dfDieselBalanceDual=hcat(dfDieselBalanceDual, DataFrame(dual_values, :auto))
 	rename!(dfDieselBalanceDual,[Symbol("Zone");[Symbol("t$t") for t in 1:T]])
@@ -54,24 +26,9 @@ function write_liquid_fuel_balance_dual(path::AbstractString, sep::AbstractStrin
 	# # Dual of storage level (state of charge) balance of each resource in each time step
 	dfJetfuelBalanceDual = DataFrame(Zone = 1:Z)
 	# Define an empty array
-	x1 = Array{Float64}(undef, Z, T)
-	dual_values =Array{Float64}(undef, Z, T)
-
-	# Loop over W separately hours_per_subperiod
-	for z in 1:Z
-		for t in 1:T
-			x1[z,t] = dual.(EP[:cLFAnnualJetfuelBalance]) #Use this for getting dual values and put in the extracted codes from PJM
-		end
-	end
-
-	# Incorporating effect of time step weights (When OperationWrapping=1) and Parameter scaling (ParameterScale=1) on dual variables
-	for z in 1:Z
-		if setup["ParameterScale"]==1
-			dual_values[z,:] = x1[z,:]./inputs["omega"] *ModelScalingFactor
-		else
-			dual_values[z,:] = x1[z,:]./inputs["omega"]
-		end
-	end
+	dual_values = Array{Float64}(undef, Z, T)
+	dual_values .= dual(EP[:cLFAnnualJetfuelBalance]) * SCALING
+	dual_values ./= transpose(omega)
 
 	dfJetfuelBalanceDual=hcat(dfJetfuelBalanceDual, DataFrame(dual_values, :auto))
 	rename!(dfJetfuelBalanceDual,[Symbol("Zone");[Symbol("t$t") for t in 1:T]])
@@ -81,24 +38,9 @@ function write_liquid_fuel_balance_dual(path::AbstractString, sep::AbstractStrin
 	# # Dual of storage level (state of charge) balance of each resource in each time step
 	dfGasolineBalanceDual = DataFrame(Zone = 1:Z)
 	# Define an empty array
-	x1 = Array{Float64}(undef, Z, T)
-	dual_values =Array{Float64}(undef, Z, T)
-
-	# Loop over W separately hours_per_subperiod
-	for z in 1:Z
-		for t in 1:T
-			x1[z,t] = dual.(EP[:cLFAnnualGasolineBalance]) #Use this for getting dual values and put in the extracted codes from PJM
-		end
-	end
-
-	# Incorporating effect of time step weights (When OperationWrapping=1) and Parameter scaling (ParameterScale=1) on dual variables
-	for z in 1:Z
-		if setup["ParameterScale"]==1
-			dual_values[z,:] = x1[z,:]./inputs["omega"] *ModelScalingFactor
-		else
-			dual_values[z,:] = x1[z,:]./inputs["omega"]
-		end
-	end
+	dual_values = Array{Float64}(undef, Z, T)
+	dual_values .= dual(EP[:cLFAnnualGasolineBalance]) * SCALING
+	dual_values ./= transpose(omega)
 
 	dfGasolineBalanceDual=hcat(dfGasolineBalanceDual, DataFrame(dual_values, :auto))
 	rename!(dfGasolineBalanceDual,[Symbol("Zone");[Symbol("t$t") for t in 1:T]])
@@ -111,24 +53,9 @@ function write_liquid_fuel_balance_dual(path::AbstractString, sep::AbstractStrin
 			# # Dual of storage level (state of charge) balance of each resource in each time step
 			dfBioethanolBalanceDual = DataFrame(Zone = 1:Z)
 			# Define an empty array
-			x1 = Array{Float64}(undef, Z, T)
-			dual_values =Array{Float64}(undef, Z, T)
-
-			# Loop over W separately hours_per_subperiod
-			for z in 1:Z
-				for t in 1:T
-					x1[z,t] = dual.(EP[:cAnnualEthanolBalance]) #Use this for getting dual values and put in the extracted codes from PJM
-				end
-			end
-
-			# Incorporating effect of time step weights (When OperationWrapping=1) and Parameter scaling (ParameterScale=1) on dual variables
-			for z in 1:Z
-				if setup["ParameterScale"]==1
-					dual_values[z,:] = x1[z,:]./inputs["omega"] *ModelScalingFactor
-				else
-					dual_values[z,:] = x1[z,:]./inputs["omega"]
-				end
-			end
+			dual_values = Array{Float64}(undef, Z, T)
+			dual_values .= dual(EP[:cAnnualEthanolBalance]) * SCALING
+			dual_values ./= transpose(omega)
 
 			dfBioethanolBalanceDual=hcat(dfBioethanolBalanceDual, DataFrame(dual_values, :auto))
 			rename!(dfBioethanolBalanceDual,[Symbol("Zone");[Symbol("t$t") for t in 1:T]])


### PR DESCRIPTION
# Description

Two places in the code require the duals to be accessed, transposed, and multiplied by the time weights and model scaling factor. This is currently done with two quite slow loops. This PR replaces the loops with broadcast methods and the transpose function.

Liquid fuels currently balances supply and demand on an annual basis. These functions will need to be changed if we change this to hourly or another time basis.

## Fixes issue \#

No associated issue

## Type of change

- [x] Performance improvement

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Example_Systems/SmallNewEngland/OneZone 
- [x] Example_Systems/SmallNewEngland/ThreeZones

**Test Configuration**:
* OS: Windows 10
* Solver: Gurobi 
* Julia version: Julia 1.10.2
* Solver version: 10.0 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run tests with my code to avoid compatibility issues
- [x] Any dependent changes have been merged and published in downstream modules
