### PR TITLE
Updated voll value for HSC

### DIFF
--- a/src/HSC/load_inputs/load_h2_demand.jl
+++ b/src/HSC/load_inputs/load_h2_demand.jl
@@ -48,9 +48,10 @@ function load_h2_demand(setup::Dict, path::AbstractString, sep::AbstractString, 
     inputs_load["pMax_H2_D_Curtail"] = zeros(H2_SEG)
     for s in 1:H2_SEG
         # Cost of each segment reported as a fraction of value of non-served energy - scaled implicitly
-        inputs_load["pC_H2_D_Curtail"][s] = collect(skipmissing(H2_load_in[!,:Cost_of_Demand_Curtailment_per_Tonne]))[s]*inputs_load["Voll"][1]
+        inputs_load["pC_H2_D_Curtail"][s] = collect(skipmissing(H2_load_in[!,:Cost_of_Demand_Curtailment_per_Tonne]))[s]*inputs_load["H2_Voll"][1]
         # Maximum hourly demand curtailable as % of the max demand (for each segment)
         inputs_load["pMax_H2_D_Curtail"][s] = collect(skipmissing(H2_load_in[!,:Max_Demand_Curtailment]))[s]
+
     end
     
     print_and_log("HSC_load_data.csv Successfully Read!")

--- a/src/HSC/model/core/h2_non_served.jl
+++ b/src/HSC/model/core/h2_non_served.jl
@@ -110,10 +110,10 @@ function h2_non_served(EP::Model, inputs::Dict, setup::Dict)
     # Add total cost contribution of non-served energy/curtailed demand to the objective function
     EP[:eObj] += eTotalH2CNSE
 
-    ## Power Balance Expressions ##
+    ## Expression to be added to H2 Balance##
     @expression(EP, eH2BalanceNse[t = 1:T, z = 1:Z], sum(vH2NSE[s, t, z] for s = 1:H2_SEG))
 
-    # Add non-served energy/curtailed demand contribution to power balance expression
+    # Add non-served energy/curtailed demand contribution to H2 balance expression
     EP[:eH2Balance] += eH2BalanceNse
 
     ### Constratints ###


### PR DESCRIPTION
Updated the code to read the correct value of lost load for HSC sector.  Previously, code was reading the value for the power sector.

# Description

Previously, line 51 of load_h2_demand.jl was reading the value of non-served energy  for the power sector rather than H2_sector

## Fixes issue \#

'No associated issue`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on SmallNewEngland/ThreeZones to verify that value of non-served energy for HSC is read to be what is input by the user in HSC_load_data.csv

- [ ] Example_Systems/SmallNewEngland/ThreeZones

**Test Configuration**:
* OS: Windows 11
* Solver: HIGHS
* Julia version: 1.10.0
* Solver version: 1.6.0

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run tests with my code to avoid compatibility issues
- [ ] Any dependent changes have been merged and published in downstream modules
