### PR TITLE
237 fix cH2GenMaxRetNoCommit constraint

### DIFF
--- a/src/HSC/model/generation/h2_production_all.jl
+++ b/src/HSC/model/generation/h2_production_all.jl
@@ -72,7 +72,7 @@ function h2_production_all(EP::Model, inputs::Dict, setup::Dict)
 
     ## Constraints on retirements and capacity additions
     # Cannot retire more capacity than existing capacity
-    @constraint(EP, cH2GenMaxRetNoCommit[k in setdiff(H2_GEN_RET_CAP, H2_GEN_NO_COMMIT)], EP[:vH2GenRetCap][k] <= dfH2Gen[!,:Existing_Cap_tonne_p_hr][k])
+    @constraint(EP, cH2GenMaxRetNoCommit[k in intersect(H2_GEN_RET_CAP, H2_GEN_NO_COMMIT)], EP[:vH2GenRetCap][k] <= dfH2Gen[!,:Existing_Cap_tonne_p_hr][k])
     @constraint(EP, cH2GenMaxRetCommit[k in intersect(H2_GEN_RET_CAP, H2_GEN_COMMIT)], dfH2Gen[!,:Cap_Size_tonne_p_hr][k] * EP[:vH2GenRetCap][k] <= dfH2Gen[!,:Existing_Cap_tonne_p_hr][k])
 
     ## Constraints on new built capacity


### PR DESCRIPTION
# Description

Fixes constraint _cH2GenMaxRetNoCommit_ by defining it over the correct set of technologies.

## Fixes issue \#

Fixes #237

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Example_Systems/SmallNewEngland/ThreeZones_Gurobi
