### PR TITLE
Bound vH2SOCw with energy capacity

### DIFF
--- a/src/HSC/model/storage/h2_long_duration_storage.jl
+++ b/src/HSC/model/storage/h2_long_duration_storage.jl
@@ -139,7 +139,7 @@ function h2_long_duration_storage(EP::Model, inputs::Dict)
 
     # Storage at beginning of each modeled period cannot exceed installed energy capacity
     @constraint(EP, cH2SoCBalLongDurationStorageUpper[y in H2_STOR_LONG_DURATION, r in MODELED_PERIODS_INDEX],
-                    vH2SOCw[y,r] <= EP[:eH2GenTotalCap][y])
+                    vH2SOCw[y,r] <= EP[:eH2TotalCapEnergy][y])
 
     # Initial storage level for representative periods must also adhere to sub-period storage inventory balance
     # Initial storage = Final storage - change in storage inventory across representative period


### PR DESCRIPTION
# Description

Fixes constraint `cH2SoCBalLongDurationStorageUpper` bounding `vH2SOCw` with total energy capacity `eH2TotalCapEnergy`

## Fixes issue \#

Fixes #246 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Example_Systems/SmallNewEngland/ThreeZones
